### PR TITLE
Fix null handling for agenda status

### DIFF
--- a/agenda.module
+++ b/agenda.module
@@ -59,7 +59,7 @@ function _prepare_agenda_edit_form(&$form, FormStateInterface $form_state) {
   $referenced_tag = \Drupal::entityTypeManager()
     ->getStorage('taxonomy_term')
     ->load($agenda_status_id);
-  $agenda_status = $referenced_tag->name->value;
+  $agenda_status = $referenced_tag ? $referenced_tag->getName() : '';
   if ($agenda_status != 'Draft') {
     // We'll prevent agenda text edits unless in Draft status
     $form['body']['#access'] = FALSE;
@@ -144,7 +144,7 @@ function _agenda_delete_validation(&$form, FormStateInterface $form_state) {
   $referenced_tag = \Drupal::entityTypeManager()
     ->getStorage('taxonomy_term')
     ->load($agenda_status_id);
-  $agenda_status = $referenced_tag->name->value;
+  $agenda_status = $referenced_tag ? $referenced_tag->getName() : '';
   if ($agenda_status != 'Draft') {
     $form_state->setError($form, 'Please change the Agenda to "Draft" status before attempting to delete.');
   }


### PR DESCRIPTION
## Summary
- prevent null reference when looking up agenda status terms

## Testing
- `php -l agenda.module` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6850575f63c88322888a9b8a18fc833f